### PR TITLE
fix order of %prefix%/%topic%/ in config schema

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -125,7 +125,7 @@
         "type": "string",
         "required": true,
         "description": "Tasmota device full topic, as shown in its MQTT settings",
-        "default": "%topic%/%prefix%/"
+        "default": "%prefix%/%topic%/"
       },
       "debug": {
         "title": "Debug",


### PR DESCRIPTION
The default MQTT full topic in Tasmota is %prefix%/%topic%/, which is
also reflected in src/base.js.  In the config.schema.json, however, the
order was reversed, presumably by accident, which presents itself as a
subtle setup hurdle for new users.